### PR TITLE
Created JSON.is<case> Variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /Packages
 /*.xcodeproj
 build/
+.swiftpm/

--- a/Sources/JSON/Coder/Decoding/_JSONKeyedValueDecoder.swift
+++ b/Sources/JSON/Coder/Decoding/_JSONKeyedValueDecoder.swift
@@ -42,14 +42,31 @@ internal struct _JSONKeyedValueDecoder<K: CodingKey>: KeyedDecodingContainerProt
         
         return try json.value(for: type, at: self.codingPath)
     }
-    
-    func decode(_ type: Bool.Type, forKey key: Key) throws -> Bool { return try _decode(type, forKey: key) }
-    func decode(_ type: Int.Type, forKey key: K)    throws -> Int { return try _decode(type, forKey: key) }
-    func decode(_ type: Float.Type, forKey key: K)  throws -> Float { return try _decode(type, forKey: key) }
+
+    func _decode<T>(_ type: T.Type, forKey key: Key)throws -> T where T: Decodable & FixedWidthInteger {
+        guard let json = self.json[key.stringValue] else {
+            throw DecodingError.badKey(key, at: self.codingPath)
+        }
+
+        return try json.number(at: self.codingPath, as: type)
+    }
+
+    func decode(_ type: Bool.Type, forKey key: Key) throws -> Bool   { return try _decode(type, forKey: key) }
+    func decode(_ type: Int.Type, forKey key: K)    throws -> Int    { return try _decode(type, forKey: key) }
+    func decode(_ type: Float.Type, forKey key: K)  throws -> Float  { return try _decode(type, forKey: key) }
     func decode(_ type: Double.Type, forKey key: K) throws -> Double { return try _decode(type, forKey: key) }
     func decode(_ type: String.Type, forKey key: K) throws -> String { return try _decode(type, forKey: key) }
     func decode<T>(_ type: T.Type, forKey key: K)   throws -> T where T : Decodable { return try _decode(type, forKey: key) }
-    
+
+    func decode(_ type: Int8.Type, forKey key: K) throws -> Int8 { return try _decode(type, forKey: key) }
+    func decode(_ type: Int16.Type, forKey key: K) throws -> Int16 { return try _decode(type, forKey: key) }
+    func decode(_ type: Int32.Type, forKey key: K) throws -> Int32 { return try _decode(type, forKey: key) }
+    func decode(_ type: Int64.Type, forKey key: K) throws -> Int64 { return try _decode(type, forKey: key) }
+    func decode(_ type: UInt8.Type, forKey key: K) throws -> UInt8 { return try _decode(type, forKey: key) }
+    func decode(_ type: UInt16.Type, forKey key: K) throws -> UInt16 { return try _decode(type, forKey: key) }
+    func decode(_ type: UInt32.Type, forKey key: K) throws -> UInt32 { return try _decode(type, forKey: key) }
+    func decode(_ type: UInt64.Type, forKey key: K) throws -> UInt64 { return try _decode(type, forKey: key) }
+
     private func _superDecoder(forKey key: CodingKey) throws -> Decoder {
         let value = self.json[key.stringValue] ?? JSON.null
         return _JSONDecoder(codingPath: self.codingPath + [key], json: value)

--- a/Sources/JSON/Coder/Decoding/_JSONSingleValueDecoder.swift
+++ b/Sources/JSON/Coder/Decoding/_JSONSingleValueDecoder.swift
@@ -21,7 +21,16 @@ internal struct _JSONSingleValueDecoder: SingleValueDecodingContainer {
     func decode(_ type: Float.Type)  throws -> Float { return try self.json.value(for: type, at: self.codingPath) }
     func decode(_ type: Double.Type) throws -> Double { return try self.json.value(for: type, at: self.codingPath) }
     func decode(_ type: String.Type) throws -> String { return try self.json.value(for: type, at: self.codingPath) }
-    
+
+    func decode(_ type: Int8.Type) throws -> Int8 { return try self.json.number(at: self.codingPath, as: type) }
+    func decode(_ type: Int16.Type) throws -> Int16 { return try self.json.number(at: self.codingPath, as: type) }
+    func decode(_ type: Int32.Type) throws -> Int32 { return try self.json.number(at: self.codingPath, as: type) }
+    func decode(_ type: Int64.Type) throws -> Int64 { return try self.json.number(at: self.codingPath, as: type) }
+    func decode(_ type: UInt8.Type) throws -> UInt8 { return try self.json.number(at: self.codingPath, as: type) }
+    func decode(_ type: UInt16.Type) throws -> UInt16 { return try self.json.number(at: self.codingPath, as: type) }
+    func decode(_ type: UInt32.Type) throws -> UInt32 { return try self.json.number(at: self.codingPath, as: type) }
+    func decode(_ type: UInt64.Type) throws -> UInt64 { return try self.json.number(at: self.codingPath, as: type) }
+
     func decode<T>(_ type: T.Type) throws -> T where T: Decodable {
         let decoder = _JSONDecoder(codingPath: self.codingPath, json: self.json)
         return try T.init(from: decoder)

--- a/Sources/JSON/Coder/Decoding/_JSONUnkeyedDecoder.swift
+++ b/Sources/JSON/Coder/Decoding/_JSONUnkeyedDecoder.swift
@@ -46,30 +46,22 @@ internal struct _JSONUnkeyedDecoder: UnkeyedDecodingContainer {
         return true
     }
     
-    mutating func decode(_ type: Bool.Type) throws -> Bool {
-        return try self.pop(as: type)
-    }
-    
-    mutating func decode(_ type: Int.Type) throws -> Int {
-        return try self.pop(as: type)
-    }
-    
-    mutating func decode(_ type: Float.Type) throws -> Float {
-        return try self.pop(as: type)
-    }
-    
-    mutating func decode(_ type: Double.Type) throws -> Double {
-        return try self.pop(as: type)
-    }
-    
-    mutating func decode(_ type: String.Type) throws -> String {
-        return try self.pop(as: type)
-    }
-    
-    mutating func decode<T>(_ type: T.Type) throws -> T where T : Decodable {
-        return try self.pop(as: type)
-    }
-    
+    mutating func decode(_ type: Bool.Type)   throws -> Bool   { return try self.pop(as: type) }
+    mutating func decode(_ type: Int.Type)    throws -> Int    { return try self.pop(as: type) }
+    mutating func decode(_ type: Float.Type)  throws -> Float  { return try self.pop(as: type) }
+    mutating func decode(_ type: Double.Type) throws -> Double { return try self.pop(as: type) }
+    mutating func decode(_ type: String.Type) throws -> String { return try self.pop(as: type) }
+    mutating func decode<T>(_ type: T.Type) throws -> T where T : Decodable { return try self.pop(as: type) }
+
+    mutating func decode(_ type: Int8.Type)   throws -> Int8   { return try self.pop(as: type) }
+    mutating func decode(_ type: Int16.Type)  throws -> Int16  { return try self.pop(as: type) }
+    mutating func decode(_ type: Int32.Type)  throws -> Int32  { return try self.pop(as: type) }
+    mutating func decode(_ type: Int64.Type)  throws -> Int64  { return try self.pop(as: type) }
+    mutating func decode(_ type: UInt8.Type)  throws -> UInt8  { return try self.pop(as: type) }
+    mutating func decode(_ type: UInt16.Type) throws -> UInt16 { return try self.pop(as: type) }
+    mutating func decode(_ type: UInt32.Type) throws -> UInt32 { return try self.pop(as: type) }
+    mutating func decode(_ type: UInt64.Type) throws -> UInt64 { return try self.pop(as: type) }
+
     // TODO: - https://github.com/apple/swift/blob/master/stdlib/public/SDK/Foundation/JSONEncoder.swift#L1852
     mutating func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type) throws -> KeyedDecodingContainer<NestedKey> where NestedKey : CodingKey {
         guard !self.isAtEnd else {

--- a/Sources/JSON/Coder/Encoding/_JSONKeyedEncoder.swift
+++ b/Sources/JSON/Coder/Encoding/_JSONKeyedEncoder.swift
@@ -19,7 +19,16 @@ internal final class _JSONKeyedEncoder<K: CodingKey>: KeyedEncodingContainerProt
     func encode(_ value: String, forKey key: Key) throws { self.container.json[key.stringValue] = value.json }
     func encode(_ value: Float, forKey key: Key)  throws { self.container.json[key.stringValue] = value.json }
     func encode(_ value: Double, forKey key: Key) throws { self.container.json[key.stringValue] = value.json }
-    
+
+    func encode(_ value: Int8, forKey key: Key)   throws { self.container.json[key.stringValue] = value.json }
+    func encode(_ value: Int16, forKey key: Key)  throws { self.container.json[key.stringValue] = value.json }
+    func encode(_ value: Int32, forKey key: Key)  throws { self.container.json[key.stringValue] = value.json }
+    func encode(_ value: Int64, forKey key: Key)  throws { self.container.json[key.stringValue] = value.json }
+    func encode(_ value: UInt8, forKey key: Key)   throws { self.container.json[key.stringValue] = value.json }
+    func encode(_ value: UInt16, forKey key: Key)  throws { self.container.json[key.stringValue] = value.json }
+    func encode(_ value: UInt32, forKey key: Key)  throws { self.container.json[key.stringValue] = value.json }
+    func encode(_ value: UInt64, forKey key: Key)  throws { self.container.json[key.stringValue] = value.json }
+
     func encode<T : Encodable>(_ value: T, forKey key: Key) throws {        
         let encoder = _JSONEncoder(codingPath: self.codingPath + [key])
         try value.encode(to: encoder)

--- a/Sources/JSON/Coder/Encoding/_JSONSingleValueEncoder.swift
+++ b/Sources/JSON/Coder/Encoding/_JSONSingleValueEncoder.swift
@@ -13,14 +13,23 @@ internal final class _JSONSingleValueEncoder: SingleValueEncodingContainer {
         self.container.json = value.json
     }
     
-    public func encodeNil()             throws { _encode(JSON.null) }
-    public func encode(_ value: Bool)   throws { _encode(value) }
-    public func encode(_ value: Int)    throws { _encode(value) }
-    public func encode(_ value: String) throws { _encode(value) }
-    public func encode(_ value: Float)  throws { _encode(value) }
-    public func encode(_ value: Double) throws { _encode(value) }
-    
-    public func encode<T : Encodable>(_ value: T) throws {
+    func encodeNil()             throws { _encode(JSON.null) }
+    func encode(_ value: Bool)   throws { _encode(value) }
+    func encode(_ value: Int)    throws { _encode(value) }
+    func encode(_ value: String) throws { _encode(value) }
+    func encode(_ value: Float)  throws { _encode(value) }
+    func encode(_ value: Double) throws { _encode(value) }
+
+    func encode(_ value: Int8)   throws { _encode(value) }
+    func encode(_ value: Int16)  throws { _encode(value) }
+    func encode(_ value: Int32)  throws { _encode(value) }
+    func encode(_ value: Int64)  throws { _encode(value) }
+    func encode(_ value: UInt8)  throws { _encode(value) }
+    func encode(_ value: UInt16) throws { _encode(value) }
+    func encode(_ value: UInt32) throws { _encode(value) }
+    func encode(_ value: UInt64) throws { _encode(value) }
+
+    func encode<T : Encodable>(_ value: T) throws {
         let encoder = _JSONEncoder(codingPath: self.codingPath)
         try value.encode(to: encoder)
         self.container.json = encoder.container.json

--- a/Sources/JSON/Coder/Encoding/_JSONUnkeyedEncoder.swift
+++ b/Sources/JSON/Coder/Encoding/_JSONUnkeyedEncoder.swift
@@ -15,14 +15,23 @@ internal final class _JSONUnkeyedEncoder: UnkeyedEncodingContainer {
         return container.json.array?.count ?? 0
     }
     
-    public func encodeNil()             throws { self.container.json.array?.append(.null) }
-    public func encode(_ value: Bool)   throws { self.container.json.array?.append(value.json) }
-    public func encode(_ value: Int)    throws { self.container.json.array?.append(value.json) }
-    public func encode(_ value: String) throws { self.container.json.array?.append(value.json) }
-    public func encode(_ value: Float)  throws { self.container.json.array?.append(value.json) }
-    public func encode(_ value: Double) throws { self.container.json.array?.append(value.json) }
-    
-    public func encode<T : Encodable>(_ value: T) throws {
+    func encodeNil()             throws { self.container.json.array?.append(.null) }
+    func encode(_ value: Bool)   throws { self.container.json.array?.append(value.json) }
+    func encode(_ value: Int)    throws { self.container.json.array?.append(value.json) }
+    func encode(_ value: String) throws { self.container.json.array?.append(value.json) }
+    func encode(_ value: Float)  throws { self.container.json.array?.append(value.json) }
+    func encode(_ value: Double) throws { self.container.json.array?.append(value.json) }
+
+    func encode(_ value: Int8)   throws { self.container.json.array?.append(value.json) }
+    func encode(_ value: Int16)  throws { self.container.json.array?.append(value.json) }
+    func encode(_ value: Int32)  throws { self.container.json.array?.append(value.json) }
+    func encode(_ value: Int64)  throws { self.container.json.array?.append(value.json) }
+    func encode(_ value: UInt8)  throws { self.container.json.array?.append(value.json) }
+    func encode(_ value: UInt16) throws { self.container.json.array?.append(value.json) }
+    func encode(_ value: UInt32) throws { self.container.json.array?.append(value.json) }
+    func encode(_ value: UInt64) throws { self.container.json.array?.append(value.json) }
+
+    func encode<T : Encodable>(_ value: T) throws {
         let encoder = _JSONEncoder(codingPath: self.codingPath + [JSON.CodingKeys(intValue: self.count)])
         try value.encode(to: encoder)
         self.container.json.array?.append(encoder.container.json)

--- a/Sources/JSON/Coder/JSON+Type.swift
+++ b/Sources/JSON/Coder/JSON+Type.swift
@@ -80,7 +80,7 @@ extension JSON {
         }
     }
     
-    fileprivate func number<T: SignedInteger>(at path: [CodingKey], as type: T.Type)throws -> T {
+    internal func number<T: FixedWidthInteger>(at path: [CodingKey], as type: T.Type)throws -> T {
         let error = DecodingError.expectedType(T.self, at: path, from: self)
 
         guard case let JSON.number(number) = self else {
@@ -94,7 +94,7 @@ extension JSON {
         }
     }
     
-    fileprivate func number<T: BinaryFloatingPoint>(at path: [CodingKey], as type: T.Type)throws -> T {
+    internal func number<T: BinaryFloatingPoint>(at path: [CodingKey], as type: T.Type)throws -> T {
         let error = DecodingError.expectedType(T.self, at: path, from: self)
         
         guard case let JSON.number(number) = self else {

--- a/Sources/JSON/Coder/JSON+Type.swift
+++ b/Sources/JSON/Coder/JSON+Type.swift
@@ -1,23 +1,61 @@
 import Foundation
 
 extension JSON {
-    
-    /// Indicates whether the `JSON` case of the currenct instance is `.object` or not.
+
+    /// Indicates whether this case is a `.null`.
+    public var isNull: Bool {
+        guard case .null = self else { return false }
+        return true
+    }
+
+    /// Indicates whether this case is a `.bool`.
+    public var isBool: Bool {
+        guard case .bool = self else { return false }
+        return true
+    }
+
+    /// Indicates whether this case is a `.string`.
+    public var isString: Bool {
+        guard case .string = self else { return false }
+        return true
+    }
+
+    /// Indicates whether this case is a `.number`.
+    public var isNumber: Bool {
+        guard case .number = self else { return false }
+        return true
+    }
+
+    /// Indicates whether this case is a `.number(.int)`.
+    public var isInt: Bool {
+        guard case let .number(num) = self, case .int = num else { return false }
+        return true
+    }
+
+    /// Indicates whether this case is a `.number(.float)`.
+    public var isFloat: Bool {
+        guard case let .number(num) = self, case .float = num else { return false }
+        return true
+    }
+
+    /// Indicates whether this case is a `.number(.double)`.
+    public var isDouble: Bool {
+        guard case let .number(num) = self, case .double = num else { return false }
+        return true
+    }
+
+    /// Indicates whether the case is a`.object`.
     public var isObject: Bool {
-        switch self {
-        case .object: return true
-        default: return false
-        }
+        guard case .object = self else { return false }
+        return true
     }
     
-    /// Indicates whether the `JSON` case of the currenct instance is `.array` or not.
+    /// Indicates whether the case is an`.array`.
     public var isArray: Bool {
-        switch self {
-        case .array: return true
-        default: return false
-        }
+        guard case .array = self else { return false }
+        return true
     }
-    
+
     func value<T>(`for` type: T.Type, at path: [CodingKey])throws -> T where T: Decodable {
         let error = DecodingError.expectedType(T.self, at: path, from: self)
         

--- a/Sources/JSON/JSON+JSONConvertible.swift
+++ b/Sources/JSON/JSON+JSONConvertible.swift
@@ -131,3 +131,23 @@ extension Dictionary: JSONRepresentable where Key == String, Value: JSONRepresen
         }
     }
 }
+
+extension FixedWidthInteger {
+    public var json: JSON {
+        return .number(.int(Int(self)))
+    }
+
+    public init?(json: JSON) {
+        guard let int = json.int else { return nil }
+        self.init(int)
+    }
+}
+
+extension Int8: JSONRepresentable { }
+extension Int16: JSONRepresentable { }
+extension Int32: JSONRepresentable { }
+extension Int64: JSONRepresentable { }
+extension UInt8: JSONRepresentable { }
+extension UInt16: JSONRepresentable { }
+extension UInt32: JSONRepresentable { }
+extension UInt64: JSONRepresentable { }

--- a/Sources/JSON/JSON.swift
+++ b/Sources/JSON/JSON.swift
@@ -56,7 +56,7 @@ import Foundation
 ///
 ///     json.users.0.name.first = "Tanner"
 @dynamicMemberLookup
-public enum JSON: Equatable, CustomStringConvertible {
+public enum JSON: Hashable, CustomStringConvertible {
     
     // MARK: - Properties
     

--- a/Sources/JSON/JSON.swift
+++ b/Sources/JSON/JSON.swift
@@ -287,7 +287,14 @@ public enum JSON: Hashable, CustomStringConvertible {
     public init(_ object: [String: JSON]) {
         self = .object(object)
     }
-    
+
+    /// Creates a `JSON` instance with the `.number` case.
+    ///
+    /// - Parameter fwi: A fixed-width integer which is converted to an `Int` and then passed into a `.number(.int)` case.
+    public init<I>(_ fwi: I) where I: FixedWidthInteger {
+        self = .number(.int(Int(fwi)))
+    }
+
     #if canImport(Foundation)
     
     /// Creates a `JSON` instance from raw JSON data.

--- a/Sources/JSON/Number.swift
+++ b/Sources/JSON/Number.swift
@@ -1,5 +1,5 @@
 /// A wrapper for standard numeric types.
-public enum Number: Codable, Equatable, CustomStringConvertible {
+public enum Number: Codable, Hashable, CustomStringConvertible {
     
     /// Wraps an `Int` instance.
     case int(Int)

--- a/Tests/JSONTests/JSONTests.swift
+++ b/Tests/JSONTests/JSONTests.swift
@@ -56,7 +56,7 @@ class JSONTests: XCTestCase {
     }
     
     func testDynamicAccessGet()throws {
-        var weather = try JSON(data: Data(json.utf8))
+        let weather = try JSON(data: Data(json.utf8))
         XCTAssertEqual(weather.minutely.data.0.time.int, 1517594040)
         
         measure {


### PR DESCRIPTION
- Create JSON.is\<case\> computed variables for checking the type of the JSON case
- Added handlers for `Int8`, `int16`, `Int32`, `Int64`, `UInt8`, `UInt16`, `UInt32`, `Uint64` to the JSON encoders and decoders.