### PR TITLE
Fixed Nested Encoding Containers

### DIFF
--- a/Sources/JSON/Coder/Encoding/_JSONKeyedEncoder.swift
+++ b/Sources/JSON/Coder/Encoding/_JSONKeyedEncoder.swift
@@ -2,46 +2,50 @@ import Foundation
 
 internal final class _JSONKeyedEncoder<K: CodingKey>: KeyedEncodingContainerProtocol {
     typealias Key = K
-    
+
+    let encoder: _JSONEncoder
     var codingPath: [CodingKey]
-    var container: JSONContainer
-    
-    init(at codingPath: [CodingKey], wrapping container: JSONContainer) {
-        self.codingPath = codingPath
-        
-        precondition(container.json.isObject, "JSON must have an object structure")
-        self.container = container
+
+    var jsonPath: [String]
+    var container: JSONContainer { self.encoder.container }
+
+    init(for encoder: _JSONEncoder, path: [CodingKey]? = nil) {
+        self.encoder = encoder
+        self.codingPath = path ?? encoder.codingPath
+
+        self.jsonPath = self.codingPath.map { $0.stringValue }
     }
     
-    func encodeNil(forKey key: Key)               throws { self.container.json[key.stringValue] = .null }
-    func encode(_ value: Bool, forKey key: Key)   throws { self.container.json[key.stringValue] = value.json }
-    func encode(_ value: Int, forKey key: Key)    throws { self.container.json[key.stringValue] = value.json }
-    func encode(_ value: String, forKey key: Key) throws { self.container.json[key.stringValue] = value.json }
-    func encode(_ value: Float, forKey key: Key)  throws { self.container.json[key.stringValue] = value.json }
-    func encode(_ value: Double, forKey key: Key) throws { self.container.json[key.stringValue] = value.json }
+    func encodeNil(forKey key: Key)               throws { self.container.assign(path: self.jsonPath, key: key.stringValue, to: .null) }
+    func encode(_ value: Bool, forKey key: Key)   throws { self.container.assign(path: self.jsonPath, key: key.stringValue, to: value.json) }
+    func encode(_ value: Int, forKey key: Key)    throws { self.container.assign(path: self.jsonPath, key: key.stringValue, to: value.json) }
+    func encode(_ value: String, forKey key: Key) throws { self.container.assign(path: self.jsonPath, key: key.stringValue, to: value.json) }
+    func encode(_ value: Float, forKey key: Key)  throws { self.container.assign(path: self.jsonPath, key: key.stringValue, to: value.json) }
+    func encode(_ value: Double, forKey key: Key) throws { self.container.assign(path: self.jsonPath, key: key.stringValue, to: value.json) }
 
-    func encode(_ value: Int8, forKey key: Key)   throws { self.container.json[key.stringValue] = value.json }
-    func encode(_ value: Int16, forKey key: Key)  throws { self.container.json[key.stringValue] = value.json }
-    func encode(_ value: Int32, forKey key: Key)  throws { self.container.json[key.stringValue] = value.json }
-    func encode(_ value: Int64, forKey key: Key)  throws { self.container.json[key.stringValue] = value.json }
-    func encode(_ value: UInt8, forKey key: Key)   throws { self.container.json[key.stringValue] = value.json }
-    func encode(_ value: UInt16, forKey key: Key)  throws { self.container.json[key.stringValue] = value.json }
-    func encode(_ value: UInt32, forKey key: Key)  throws { self.container.json[key.stringValue] = value.json }
-    func encode(_ value: UInt64, forKey key: Key)  throws { self.container.json[key.stringValue] = value.json }
+    func encode(_ value: Int8, forKey key: Key)   throws { self.container.assign(path: self.jsonPath, key: key.stringValue, to: value.json) }
+    func encode(_ value: Int16, forKey key: Key)  throws { self.container.assign(path: self.jsonPath, key: key.stringValue, to: value.json) }
+    func encode(_ value: Int32, forKey key: Key)  throws { self.container.assign(path: self.jsonPath, key: key.stringValue, to: value.json) }
+    func encode(_ value: Int64, forKey key: Key)  throws { self.container.assign(path: self.jsonPath, key: key.stringValue, to: value.json) }
+    func encode(_ value: UInt8, forKey key: Key)   throws { self.container.assign(path: self.jsonPath, key: key.stringValue, to: value.json) }
+    func encode(_ value: UInt16, forKey key: Key)  throws { self.container.assign(path: self.jsonPath, key: key.stringValue, to: value.json) }
+    func encode(_ value: UInt32, forKey key: Key)  throws { self.container.assign(path: self.jsonPath, key: key.stringValue, to: value.json) }
+    func encode(_ value: UInt64, forKey key: Key)  throws { self.container.assign(path: self.jsonPath, key: key.stringValue, to: value.json) }
 
-    func encode<T : Encodable>(_ value: T, forKey key: Key) throws {        
-        let encoder = _JSONEncoder(codingPath: self.codingPath + [key])
-        try value.encode(to: encoder)
-        self.container.json[key.stringValue] = encoder.container.json
+    func encode<T : Encodable>(_ value: T, forKey key: Key) throws {
+        self.encoder.codingPath.append(key)
+        defer { self.encoder.codingPath.removeLast() }
+
+        try value.encode(to: self.encoder)
     }
     
     func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type, forKey key: K) -> KeyedEncodingContainer<NestedKey> where NestedKey : CodingKey {
-        let container = _JSONKeyedEncoder<NestedKey>(at: self.codingPath + [key], wrapping: self.container)
+        let container = _JSONKeyedEncoder<NestedKey>(for: self.encoder, path: self.codingPath + [key])
         return .init(container)
     }
     
     func nestedUnkeyedContainer(forKey key: K) -> UnkeyedEncodingContainer {
-        return _JSONUnkeyedEncoder(at: self.codingPath + [key], wrapping: self.container)
+        return _JSONUnkeyedEncoder(for: self.encoder, path: self.codingPath + [key])
     }
     
     func superEncoder() -> Encoder {

--- a/Sources/JSON/Coder/Encoding/_JSONSingleValueEncoder.swift
+++ b/Sources/JSON/Coder/Encoding/_JSONSingleValueEncoder.swift
@@ -1,16 +1,16 @@
 import Foundation
 
 internal final class _JSONSingleValueEncoder: SingleValueEncodingContainer {
+    let encoder:_JSONEncoder
     var codingPath: [CodingKey]
-    var container: JSONContainer
     
-    init(at codingPath: [CodingKey], wrapping container: JSONContainer) {
-        self.codingPath = codingPath
-        self.container = container
+    init(for encoder: _JSONEncoder, path: [CodingKey]? = nil) {
+        self.encoder = encoder
+        self.codingPath = path ?? encoder.codingPath
     }
     
     func _encode<T>(_ value: T) where T: SafeJSONRepresentable {
-        self.container.json = value.json
+        self.encoder.container.assign(path: self.codingPath.map { $0.stringValue }, to: value.json)
     }
     
     func encodeNil()             throws { _encode(JSON.null) }
@@ -30,8 +30,6 @@ internal final class _JSONSingleValueEncoder: SingleValueEncodingContainer {
     func encode(_ value: UInt64) throws { _encode(value) }
 
     func encode<T : Encodable>(_ value: T) throws {
-        let encoder = _JSONEncoder(codingPath: self.codingPath)
-        try value.encode(to: encoder)
-        self.container.json = encoder.container.json
+        try value.encode(to: self.encoder)
     }
 }

--- a/Sources/JSON/Coder/Encoding/_JSONUnkeyedEncoder.swift
+++ b/Sources/JSON/Coder/Encoding/_JSONUnkeyedEncoder.swift
@@ -1,49 +1,50 @@
 import Foundation
 
 internal final class _JSONUnkeyedEncoder: UnkeyedEncodingContainer {
+    var encoder: _JSONEncoder
     var codingPath: [CodingKey]
-    var container: JSONContainer
-    
-    init(at codingPath: [CodingKey], wrapping container: JSONContainer) {
-        self.codingPath = codingPath
-        
-        precondition(container.json.isArray, "JSON structure must be an array")
-        self.container = container
+
+    var jsonPath: [String]
+    var container: JSONContainer { self.encoder.container }
+
+    init(for encoder: _JSONEncoder, path: [CodingKey]? = nil) {
+        self.encoder = encoder
+        self.codingPath = path ?? encoder.codingPath
+
+        self.jsonPath = self.codingPath.map { $0.stringValue }
     }
     
     var count: Int {
-        return container.json.array?.count ?? 0
+        return encoder.container.json.array?.count ?? 0
     }
     
-    func encodeNil()             throws { self.container.json.array?.append(.null) }
-    func encode(_ value: Bool)   throws { self.container.json.array?.append(value.json) }
-    func encode(_ value: Int)    throws { self.container.json.array?.append(value.json) }
-    func encode(_ value: String) throws { self.container.json.array?.append(value.json) }
-    func encode(_ value: Float)  throws { self.container.json.array?.append(value.json) }
-    func encode(_ value: Double) throws { self.container.json.array?.append(value.json) }
+    func encodeNil()             throws { self.container.assign(path: self.jsonPath, to: .null) }
+    func encode(_ value: Bool)   throws { self.container.assign(path: self.jsonPath, to: value.json) }
+    func encode(_ value: Int)    throws { self.container.assign(path: self.jsonPath, to: value.json) }
+    func encode(_ value: String) throws { self.container.assign(path: self.jsonPath, to: value.json) }
+    func encode(_ value: Float)  throws { self.container.assign(path: self.jsonPath, to: value.json) }
+    func encode(_ value: Double) throws { self.container.assign(path: self.jsonPath, to: value.json) }
 
-    func encode(_ value: Int8)   throws { self.container.json.array?.append(value.json) }
-    func encode(_ value: Int16)  throws { self.container.json.array?.append(value.json) }
-    func encode(_ value: Int32)  throws { self.container.json.array?.append(value.json) }
-    func encode(_ value: Int64)  throws { self.container.json.array?.append(value.json) }
-    func encode(_ value: UInt8)  throws { self.container.json.array?.append(value.json) }
-    func encode(_ value: UInt16) throws { self.container.json.array?.append(value.json) }
-    func encode(_ value: UInt32) throws { self.container.json.array?.append(value.json) }
-    func encode(_ value: UInt64) throws { self.container.json.array?.append(value.json) }
+    func encode(_ value: Int8)   throws { self.container.assign(path: self.jsonPath, to: value.json) }
+    func encode(_ value: Int16)  throws { self.container.assign(path: self.jsonPath, to: value.json) }
+    func encode(_ value: Int32)  throws { self.container.assign(path: self.jsonPath, to: value.json) }
+    func encode(_ value: Int64)  throws { self.container.assign(path: self.jsonPath, to: value.json) }
+    func encode(_ value: UInt8)  throws { self.container.assign(path: self.jsonPath, to: value.json) }
+    func encode(_ value: UInt16) throws { self.container.assign(path: self.jsonPath, to: value.json) }
+    func encode(_ value: UInt32) throws { self.container.assign(path: self.jsonPath, to: value.json) }
+    func encode(_ value: UInt64) throws { self.container.assign(path: self.jsonPath, to: value.json) }
 
     func encode<T : Encodable>(_ value: T) throws {
-        let encoder = _JSONEncoder(codingPath: self.codingPath + [JSON.CodingKeys(intValue: self.count)])
         try value.encode(to: encoder)
-        self.container.json.array?.append(encoder.container.json)
     }
     
     func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type) -> KeyedEncodingContainer<NestedKey> where NestedKey : CodingKey {
-        let container = _JSONKeyedEncoder<NestedKey>(at: self.codingPath + [JSON.CodingKeys(intValue: self.count)], wrapping: self.container)
+        let container = _JSONKeyedEncoder<NestedKey>(for: self.encoder)
         return .init(container)
     }
     
     func nestedUnkeyedContainer() -> UnkeyedEncodingContainer {
-        return _JSONUnkeyedEncoder(at: self.codingPath + [JSON.CodingKeys(intValue: self.count)], wrapping: self.container)
+        return _JSONUnkeyedEncoder(for: self.encoder)
     }
     
     func superEncoder() -> Encoder {

--- a/Tests/JSONTests/JSONCodingTests.swift
+++ b/Tests/JSONTests/JSONCodingTests.swift
@@ -103,7 +103,23 @@ final class JSONCodingTests: XCTestCase {
             }
         }
     }
-    
+
+    func testDecodeNested() throws {
+        let data = nestedJSON.data(using: .utf8)!
+        let user = try JSONDecoder().decode(NestedUser.self, from: data)
+
+        XCTAssertEqual(user, NestedUser.default)
+    }
+
+    @available(OSX 10.13, *)
+    func testEncodeNested() throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        
+        let data = try encoder.encode(NestedUser.default)
+        XCTAssertEqual(String(decoding: data, as: UTF8.self), nestedJSON)
+    }
+
     func testDecodingNestedJSON() {
         do {
             let data = json.data(using: .utf8)!

--- a/Tests/JSONTests/NestedData.swift
+++ b/Tests/JSONTests/NestedData.swift
@@ -1,0 +1,48 @@
+let nestedJSON = """
+{
+  "age" : 42,
+  "name" : {
+    "first" : "Ceicl",
+    "last" : "Doohickey"
+  }
+}
+"""
+
+struct NestedUser: Codable, Equatable {
+    let age: Int
+    let firstName: String
+    let lastName: String
+
+    static let `default`: NestedUser = NestedUser(age: 42, firstName: "Ceicl", lastName: "Doohickey")
+
+    init(age: Int, firstName: String, lastName: String) {
+        self.age = age
+        self.firstName = firstName
+        self.lastName = lastName
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.age = try container.decode(Int.self, forKey: .age)
+
+        let name = try container.nestedContainer(keyedBy: CodingKeys.self, forKey: .name)
+        self.firstName = try name.decode(String.self, forKey: .first)
+        self.lastName = try name.decode(String.self, forKey: .last)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.age, forKey: .age)
+
+        var name = container.nestedContainer(keyedBy: CodingKeys.self, forKey: .name)
+        try name.encode(self.firstName, forKey: .first)
+        try name.encode(self.lastName, forKey: .last)
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case age
+        case first
+        case last
+        case name
+    }
+}


### PR DESCRIPTION
When a container was created from another container using a `nested` method, that returned encoding container didn't properly reference the JSON container to encode its JSON into. The structure of encoding has been changed so that a single JSONEncoder with a container is passed around, along with the path in the JSON that the values should be encoded too.