### PR TITLE
Fix Uint coding when wrapped by a SingleValueContainer

### DIFF
--- a/Sources/JSON/Coder/Decoding/_JSONKeyedValueDecoder.swift
+++ b/Sources/JSON/Coder/Decoding/_JSONKeyedValueDecoder.swift
@@ -53,6 +53,7 @@ internal struct _JSONKeyedValueDecoder<K: CodingKey>: KeyedDecodingContainerProt
 
     func decode(_ type: Bool.Type, forKey key: Key) throws -> Bool   { return try _decode(type, forKey: key) }
     func decode(_ type: Int.Type, forKey key: K)    throws -> Int    { return try _decode(type, forKey: key) }
+    func decode(_ type: UInt.Type, forKey key: K)   throws -> UInt   { return try _decode(type, forKey: key) }
     func decode(_ type: Float.Type, forKey key: K)  throws -> Float  { return try _decode(type, forKey: key) }
     func decode(_ type: Double.Type, forKey key: K) throws -> Double { return try _decode(type, forKey: key) }
     func decode(_ type: String.Type, forKey key: K) throws -> String { return try _decode(type, forKey: key) }

--- a/Sources/JSON/Coder/Decoding/_JSONSingleValueDecoder.swift
+++ b/Sources/JSON/Coder/Decoding/_JSONSingleValueDecoder.swift
@@ -18,6 +18,7 @@ internal struct _JSONSingleValueDecoder: SingleValueDecodingContainer {
     
     func decode(_ type: Bool.Type)   throws -> Bool { return try self.json.value(for: type, at: self.codingPath) }
     func decode(_ type: Int.Type)    throws -> Int { return try self.json.value(for: type, at: self.codingPath) }
+    func decode(_ type: UInt.Type)   throws -> UInt { return try self.json.value(for: type, at: self.codingPath) }
     func decode(_ type: Float.Type)  throws -> Float { return try self.json.value(for: type, at: self.codingPath) }
     func decode(_ type: Double.Type) throws -> Double { return try self.json.value(for: type, at: self.codingPath) }
     func decode(_ type: String.Type) throws -> String { return try self.json.value(for: type, at: self.codingPath) }

--- a/Sources/JSON/Coder/Decoding/_JSONUnkeyedDecoder.swift
+++ b/Sources/JSON/Coder/Decoding/_JSONUnkeyedDecoder.swift
@@ -48,6 +48,7 @@ internal struct _JSONUnkeyedDecoder: UnkeyedDecodingContainer {
     
     mutating func decode(_ type: Bool.Type)   throws -> Bool   { return try self.pop(as: type) }
     mutating func decode(_ type: Int.Type)    throws -> Int    { return try self.pop(as: type) }
+    mutating func decode(_ type: UInt.Type)   throws -> UInt   { return try self.pop(as: type) }
     mutating func decode(_ type: Float.Type)  throws -> Float  { return try self.pop(as: type) }
     mutating func decode(_ type: Double.Type) throws -> Double { return try self.pop(as: type) }
     mutating func decode(_ type: String.Type) throws -> String { return try self.pop(as: type) }

--- a/Sources/JSON/Coder/Encoding/_JSONKeyedEncoder.swift
+++ b/Sources/JSON/Coder/Encoding/_JSONKeyedEncoder.swift
@@ -19,6 +19,7 @@ internal final class _JSONKeyedEncoder<K: CodingKey>: KeyedEncodingContainerProt
     func encodeNil(forKey key: Key)               throws { self.container.assign(path: self.jsonPath, key: key.stringValue, to: .null) }
     func encode(_ value: Bool, forKey key: Key)   throws { self.container.assign(path: self.jsonPath, key: key.stringValue, to: value.json) }
     func encode(_ value: Int, forKey key: Key)    throws { self.container.assign(path: self.jsonPath, key: key.stringValue, to: value.json) }
+    func encode(_ value: UInt, forKey key: Key)   throws { self.container.assign(path: self.jsonPath, key: key.stringValue, to: value.json) }
     func encode(_ value: String, forKey key: Key) throws { self.container.assign(path: self.jsonPath, key: key.stringValue, to: value.json) }
     func encode(_ value: Float, forKey key: Key)  throws { self.container.assign(path: self.jsonPath, key: key.stringValue, to: value.json) }
     func encode(_ value: Double, forKey key: Key) throws { self.container.assign(path: self.jsonPath, key: key.stringValue, to: value.json) }

--- a/Sources/JSON/Coder/Encoding/_JSONSingleValueEncoder.swift
+++ b/Sources/JSON/Coder/Encoding/_JSONSingleValueEncoder.swift
@@ -16,6 +16,7 @@ internal final class _JSONSingleValueEncoder: SingleValueEncodingContainer {
     func encodeNil()             throws { _encode(JSON.null) }
     func encode(_ value: Bool)   throws { _encode(value) }
     func encode(_ value: Int)    throws { _encode(value) }
+    func encode(_ value: UInt)   throws { _encode(value) }
     func encode(_ value: String) throws { _encode(value) }
     func encode(_ value: Float)  throws { _encode(value) }
     func encode(_ value: Double) throws { _encode(value) }

--- a/Sources/JSON/Coder/Encoding/_JSONUnkeyedEncoder.swift
+++ b/Sources/JSON/Coder/Encoding/_JSONUnkeyedEncoder.swift
@@ -21,6 +21,7 @@ internal final class _JSONUnkeyedEncoder: UnkeyedEncodingContainer {
     func encodeNil()             throws { self.container.assign(path: self.jsonPath, to: .null) }
     func encode(_ value: Bool)   throws { self.container.assign(path: self.jsonPath, to: value.json) }
     func encode(_ value: Int)    throws { self.container.assign(path: self.jsonPath, to: value.json) }
+    func encode(_ value: UInt)   throws { self.container.assign(path: self.jsonPath, to: value.json) }
     func encode(_ value: String) throws { self.container.assign(path: self.jsonPath, to: value.json) }
     func encode(_ value: Float)  throws { self.container.assign(path: self.jsonPath, to: value.json) }
     func encode(_ value: Double) throws { self.container.assign(path: self.jsonPath, to: value.json) }

--- a/Sources/JSON/JSON+JSONConvertible.swift
+++ b/Sources/JSON/JSON+JSONConvertible.swift
@@ -160,6 +160,18 @@ extension FixedWidthInteger {
     }
 }
 
+/// Handle `UInt` as a special-case: round-trip it through `Int` by bit pattern.
+extension UInt: JSONRepresentable {
+    public var json: JSON {
+        return .number(.int(Int(bitPattern: self)))
+    }
+    
+    public init?(json: JSON) {
+        guard let int = json.int else { return nil }
+        self.init(bitPattern: int)
+    }
+}
+
 extension Int8: JSONRepresentable { }
 extension Int16: JSONRepresentable { }
 extension Int32: JSONRepresentable { }

--- a/Tests/JSONTests/JSONCodingTests.swift
+++ b/Tests/JSONTests/JSONCodingTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import JSON
+import Foundation
 
 final class JSONCodingTests: XCTestCase {
     private var userJSON: JSON = [
@@ -265,6 +266,33 @@ final class JSONCodingTests: XCTestCase {
         XCTAssertEqual(decoded.name, "same ol'")
     }
     
+    func testCodingUIntAsSingleValue() throws {
+        struct Test: Codable {
+            let value: UInt
+            init(value: UInt) {
+                self.value = value
+            }
+            init(from decoder: Decoder) throws {
+                let container = try decoder.singleValueContainer()
+                self.value = try container.decode(UInt.self)
+            }
+            func encode(to encoder: Encoder) throws {
+                var container = encoder.singleValueContainer()
+                try container.encode(self.value)
+            }
+        }
+        
+        let signed = Int.random(in: (Int.min ... Int.max))
+        let unsigned: UInt = .init(bitPattern: signed)
+        let subject = Test(value: unsigned)
+        let json = try JSONCoder.encode(subject)
+        
+        XCTAssertEqual(json.int, Int(bitPattern: subject.value))
+        
+        let decoded = try JSONCoder.decode(Test.self, from: json)
+        
+        XCTAssertEqual(decoded.value, subject.value)
+    }
     
     // MARK: - Helpers
     


### PR DESCRIPTION
Attempting to encode a `Uint` into a `SingleValueContainer` when the encoder is `JSONCoder` will crash in an infinite recursion. Explicitly round-trip `UInt` through `Int` by reinterpreting its bit pattern (previously was using the plain Int initializer for conversion, creating additional issues for values greater than `Int.max`).